### PR TITLE
Changed deprecated ARWorldTrackingSessionConfiguration

### DIFF
--- a/AR-Portal/ViewController.swift
+++ b/AR-Portal/ViewController.swift
@@ -64,7 +64,7 @@ class ViewController: UIViewController, ARSCNViewDelegate {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        let configuration = ARWorldTrackingSessionConfiguration()
+        let configuration = ARWorldTrackingConfiguration()
         configuration.planeDetection = .horizontal
         configuration.isLightEstimationEnabled = true
         


### PR DESCRIPTION
Hey,

thanks for cool example of arkit. I've noticed that class ARWorldTrackingSessionConfiguration is deprecated since iOS 11 beta 5, ARWorldTrackingConfiguration should be used from now, so I changed it.

Keep up the good work!